### PR TITLE
Pages CSS & icons fix

### DIFF
--- a/head_covis.php
+++ b/head_covis.php
@@ -41,7 +41,6 @@ if($EXTERNAL_COMPONENTS) {
 <link type="text/css" rel="stylesheet" href="./css/menu.css">
 <link type="text/css" rel="stylesheet" href="./css/main.css">
 <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700" rel="stylesheet">
-<link type="text/css" rel="stylesheet" href="./css/font-awesome.min.css">
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
 <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <script type="text/javascript" src="./js/menu.js "></script>

--- a/knowledge-map.php
+++ b/knowledge-map.php
@@ -6,6 +6,8 @@ include 'config.php';
 
 <head>
 
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap.min.css">
+    <link type="text/css" rel="stylesheet" href="./css/font-awesome.min.css">
     <?php
         $title = "COVID-19 Knowledge Map - CoVis";
         include 'head_covis.php'


### PR DESCRIPTION
I fixed all the CSS and icons that broke after the #8 hotfix. 

Now the FA icons should be loaded correctly in the knowledge map, but at the same time nothing should be broken in other pages.